### PR TITLE
Moved general dependencies into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "url": "https://github.com/noppoMan/npdynamodb-typecast/issues"
   },
   "homepage": "https://github.com/noppoMan/npdynamodb-typecast",
+  "dependencies": {
+    "bluebird": "^2.9.34",
+    "lodash": "^3.10.1"
+  },
   "devDependencies": {
     "aws-sdk": "^2.1.42",
-    "bluebird": "^2.9.34",
-    "lodash": "^3.10.1",
     "npdynamodb": "^0.2.5"
   }
 }


### PR DESCRIPTION
This project depends on the specified libraries. Due to the nature of npm@3 the dependencies are usually installed one level above (with npdynamodb) but since the version of `lodash` had a significant [upgrade to 4.0.0](https://github.com/lodash/lodash/wiki/Changelog#v400) which breaks the dependencies.
